### PR TITLE
Make created links markdown conform

### DIFF
--- a/autoload/waikiki.vim
+++ b/autoload/waikiki.vim
@@ -174,9 +174,10 @@ function! waikiki#FollowLink(...) abort
       endif
       let target = s:PromptForTarget(targetlist)
     endif
-    let finaltarget = s:JoinPath(curpath, target)
+    let nospacetarget = substitute(target, ' ', '', 'g')
+    let finaltarget = s:JoinPath(curpath, nospacetarget)
     if curlink == ""
-      call s:InsertLinkCode(name, target)
+      call s:InsertLinkCode(name, nospacetarget)
     endif
   endif
 


### PR DESCRIPTION
Often I create wiki pages for projects like:

```md
A project
```
The follow link function creates:
```
[A project](A project.md)
```
Which is unfortunately not markdown conform. See [CommonMark Spec](https://spec.commonmark.org/0.28/#link-destination) and I cant be bothered to correct it by hand. So a little hacky patch...